### PR TITLE
bug fix: encoding missing from open()

### DIFF
--- a/geotext/geotext.py
+++ b/geotext/geotext.py
@@ -42,7 +42,7 @@ def read_table(filename, usecols=(0, 1), sep='\t', comment='#', encoding='utf-8'
     A dictionary with the same length as the number of lines in `filename`
     """
 
-    with open(filename, 'r') as f:
+    with open(filename, 'rt', encoding=encoding) as f:
         # skip initial lines
         for _ in range(skip):
             next(f)


### PR DESCRIPTION
Encoding option that is passed to read_table was never passed to open() command.

Should fix ISSUE #8: UnicodeDecodeError: 'gbk' codec can't decode byte 0xbf in position 2: illegal multibyte sequence